### PR TITLE
Added ability to pass in complete device name for alsaaudio sampler.

### DIFF
--- a/supersid/find_alsa_devices.py
+++ b/supersid/find_alsa_devices.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+"""
+Module for printing the names of all the audio recording devices.
+
+There may be several audio capture devices on your system.
+You will need to pick one of these strings to give as the value of
+the "Device" parameter in the [Capture] section of the supersid.cfg file.
+"""
+import pprint
+import alsaaudio
+
+device_list = alsaaudio.pcms(alsaaudio.PCM_CAPTURE)
+
+pprint.pprint(device_list)


### PR DESCRIPTION
Updated to use pyalsaaudio 0.9.0. Some of the parameters to alsaaudio.PCM
have changed and some calls have been deprecated.

Added find_alsa_devices.py script to show a list of all the audio capture
devices on the system.