### PR TITLE
ConfigHelp.md: Fix format/rendering issue in documentation

### DIFF
--- a/docs/ConfigHelp.md
+++ b/docs/ConfigHelp.md
@@ -18,6 +18,7 @@ The configuration file is a simple text file formatted as a classic '.ini' struc
   * [FTP](#id-section5)
   
 <div id='id-section1'/>
+
 ## [PARAMETERS] ##
 This section groups most of the parameters identifying your SuperSID monitor. Some optional parameters offer the possibility to change some default values used by the program.
 
@@ -53,6 +54,7 @@ Version 1.4: FTP information are no longer part of the [PARAMETERS] section. Ref
   * number_of_stations: specify the number of stations to monitor. Each station is described within its own section.
 
 <div id='id-section2'/>
+
 ## [STATION_x] ##
 Each station to monitor is enumerated from 1 till n=*number_of_stations*. For each station, one must provide:
   * call_sign: Station ID (various VLF station lists exist like [AAVSO's] (http://www.aavso.org/vlf-station-list) and [Wikipedia's] (http://en.wikipedia.org/wiki/Very_low_frequency#List_of_VLF_transmissions))
@@ -60,6 +62,7 @@ Each station to monitor is enumerated from 1 till n=*number_of_stations*. For ea
   * color: [rgbyw] to draw multiple graph together in *SuperSID_plot.py*.
   
 <div id='id-section3'/>
+
 ## [Capture] ##
 This section can be omitted if you plan to use the 'pyaudio' library. If you want to use the "alsaaudio" library then you can declare:
   * Audio: python library to use **alsaaudio** or **pyaudio** (default), **server** reserved for client/server future dev.
@@ -67,6 +70,7 @@ This section can be omitted if you plan to use the 'pyaudio' library. If you wan
   * PeriodSize: [for alsaaudio only] period size for capture. Default is '128'.
   
 <div id='id-section4'/>
+
 ## [Email] ##
 The 'supersid_plot.py' program can send you an email with the attached plot as a PDF file. In order to use this feature, you must provide the information necessary to contact your email server as well as which email to use.
   * from_mail: sender's emai
@@ -76,6 +80,7 @@ The 'supersid_plot.py' program can send you an email with the attached plot as a
   * email_password: [optional] if your server requires a password for identification
   
 <div id='id-section5'/>
+
 ## [FTP] ##
 Group all parameters to send data to an FTP server i.e. Standford data repository.
   * automatic_upload: [yes/no] if set to 'yes' then trigger the FTP data upload

--- a/supersid/find_alsa_devices.py
+++ b/supersid/find_alsa_devices.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+"""
+Module for printing the names of all the audio recording devices.
+
+There may be several audio capture devices on your system.
+You will need to pick one of these strings to give as the value of
+the "Device" parameter in the [Capture] section of the supersid.cfg file.
+"""
+import pprint
+import alsaaudio
+
+device_list = alsaaudio.pcms(alsaaudio.PCM_CAPTURE)
+
+pprint.pprint(device_list)

--- a/supersid/logger.py
+++ b/supersid/logger.py
@@ -41,13 +41,11 @@ class Logger():
             self.controller.isSuperSID = False
             self.config["stationid"] = self.config.stations[0][CALL_SIGN]
             self.config["frequency"] = self.config.stations[0][FREQUENCY]
-            self.config['log_format'] = SID_FORMAT
         elif len(self.config.stations) > 1:
             # more than one station to monitor, let's default to SuperSId file format
             self.controller.isSuperSID = True
             self.config["stations"] = ",".join([s[CALL_SIGN] for s in self.config.stations])
             self.config["frequencies"] = ",".join([s[FREQUENCY] for s in self.config.stations])
-            self.config['log_format'] = SUPERSID_FORMAT
         else:
             print("Error: no station to log???")
             exit(5)
@@ -80,16 +78,15 @@ class Logger():
     def log_sid_format(self, stations,  filename='', log_type=FILTERED, extended = False):
         """ One file per station. By default, buffered data is filtered."""
         filenames = []
-        for station in stations:       
+        for station in stations:
             my_filename = self.config.data_path + (filename or self.sid_file.get_sid_filename(station['call_sign']))
             filenames.append(my_filename)
             self.sid_file.write_data_sid(station, my_filename, log_type, extended=extended, bema_wing=self.config["bema_wing"])
         return filenames
-    
+
     def log_supersid_format(self, stations, filename='', log_type=FILTERED, extended = False):
         """Cascade all buffers in one file."""
         my_filename = filename if filename and path.isabs(filename) \
                       else self.config.data_path + (filename or self.sid_file.get_supersid_filename())
         self.sid_file.write_data_supersid(my_filename, log_type, extended=extended, bema_wing=self.config["bema_wing"])
         return [my_filename]
-    

--- a/supersid/noaa_flares.py
+++ b/supersid/noaa_flares.py
@@ -31,7 +31,10 @@ class NOAA_flares(object):
         today = date.today()
         self.XRAlist = []
 
-        if today.year==int(self.day[:4]):
+        # Starting in year 2017, NOAA makes the data available via FTP.
+        # Earlier year data is available via HTTP.
+        # So need to decide how to fetch the data based on the date.
+        if int(self.day[:4]) >= 2017:
             # given day is in the current year --> fetch data by FTP
             self.ftp_NOAA()
         else:
@@ -134,4 +137,6 @@ if __name__ == '__main__':
     flare = NOAA_flares("20140104")
     print(flare.day, "\n", flare.print_XRAlist(), "\n")
     flare = NOAA_flares("20170104")
+    print(flare.day, "\n", flare.print_XRAlist(), "\n")
+    flare = NOAA_flares("20201211")
     print(flare.day, "\n", flare.print_XRAlist(), "\n")

--- a/supersid/noaa_flares.py
+++ b/supersid/noaa_flares.py
@@ -35,9 +35,10 @@ class NOAA_flares(object):
         # Earlier year data is available via HTTP.
         # So need to decide how to fetch the data based on the date.
         if int(self.day[:4]) >= 2017:
-            # given day is in the current year --> fetch data by FTP
+            # given day is 2017 or later --> fetch data by FTP
             self.ftp_NOAA()
         else:
+            # given day is 2016 or earlier --> fetch data by https
             # if the file is NOT in the ../PRIVATE/ directory the we need to fetch it first
             # then read line by line to grab the data from the expected day
             file_path = self.http_ngdc()

--- a/supersid/sidfile.py
+++ b/supersid/sidfile.py
@@ -385,12 +385,12 @@ class SidFile():
             dmin[length+bema_wing:length+bema_wing*2] = dmin[length+bema_wing-1]
             # Moving Average. This actually truncates array to original size
             #daverage = movavg(dmin, (bema_wing*2+1))
-            def movang(a, n) :
+            def movavg(a, n) :
                 ret = np.cumsum(a, dtype=float)
                 ret[n:] = ret[n:] - ret[:-n]
                 return ret[n - 1:] / n
-            daverage = movavg(dmin, (bema_wing*2+1))     
-         
+            daverage = movavg(dmin, (bema_wing*2+1))
+
             if gmt_offset == 0:
                 return daverage
             else:


### PR DESCRIPTION
There is a small formatting/rendering issue for the markdown `ConfigHelp.md` documentation file. 

Some sections are highlighted by `div` tags (example : `<div id='id-section1'/>`)
These tags are currently directly followed by subsection titles (example : `## [PARAMETERS] ##`)

**Issue** : the subsection title is not properly rendered on the web interface. 

**Solution** : There should be an empty line after those tags for having a proper rendering of the subsection titles. 

This PR fixes this rendering issue by adding the appropriate empty lines after the `div` tags. 
